### PR TITLE
Fix changelog_parser action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## [v0.11.1] - 2020-10-04
+## [0.11.1] - 2020-10-04
 ### Changed
 - (Linux) Fix search path for config file and assets
 
-## [v0.11.0] - 2020-10-04
+## [0.11.0] - 2020-10-04
 ### Added
 - (Linux) Added support for wlroots based compositors on Wayland.
 - (Windows) Added an icon for the executable
@@ -13,11 +13,11 @@
 - (Linux) Improved NVENC, it now offloads converting images from RGB to NV12
 - (Linux) Fixed a bug causes stuttering
 
-## [v0.10.1] - 2020-08-21
+## [0.10.1] - 2020-08-21
 ### Changed
 - (Linux) Re-enabled KMS
 
-## [v0.10.0] - 2020-08-20
+## [0.10.0] - 2020-08-20
 ### Added
 - Added support for Rumble with gamepads.
 - Added support for keyboard shortcuts <--- See the README for details.
@@ -29,7 +29,7 @@
 - (Linux) VAAPI hardware encoding now works on Intel i7-6700 at least. <-- For the best experience, using ffmpeg version 4.3 or higher is recommended.
 - (Windows) Installing from debian package shouldn't overwrite your configuration files anymore. <-- It's recommended that you back up `/etc/sunshine/` before testing this.
 
-## [v0.9.0] - 2020-07-11
+## [0.9.0] - 2020-07-11
 ### Added
 - Added audio encryption
 - (Linux) Added basic NVENC support on Linux
@@ -40,43 +40,43 @@
 - Drastically reduced chance of being forced to skip error correction due to video frame size
 - (Linux) sunshine.service will be installed automatically.
 
-## [v0.8.0] - 2020-06-30
+## [0.8.0] - 2020-06-30
 ### Added
 - Added mDNS support: Moonlight will automatically find Sunshine.
 - Added UPnP support. It's off by default.
 
-## [v0.7.7] - 2020-06-24
+## [0.7.7] - 2020-06-24
 ### Added
 - (Linux) Added installation package for Debian
 ### Changed
 - Fixed incorrect scaling for absolute mouse coordinates when using multiple monitors.
 - Fixed incorrect colors when scaling for software encoder
 
-## [v0.7.1] - 2020-06-18
+## [0.7.1] - 2020-06-18
 ### Changed
 - (Linux) Fixed an issue where it was impossible to start sunshine on ubuntu 20.04
 
-## [v0.7.0] - 2020-06-16
+## [0.7.0] - 2020-06-16
 ### Added
 - Added a Web Manager. Accessible through: https://localhost:47990 or https://<ip of your pc>:47990
 - (Linux) Added hardware encoding support for AMD on Linux
 ### Changed
 - (Linux) Moved certificates and saved pairings generated during runtime to .config/sunshine on Linux
 
-## [v0.6.0] - 2020-05-26
+## [0.6.0] - 2020-05-26
 ### Added
 - Added support for surround audio
 ### Changed
 - Maintain aspect ratio when scaling video
 - Fix issue where Sunshine is forced to drop frames when they are too large
 
-## [v0.5.0] - 2020-05-13
+## [0.5.0] - 2020-05-13
 ### Added
 - Added support for absolute mouse coordinates
 - (Linux) Added support for streaming specific monitor on Linux
 - (Windows) Added support for AMF on Windows
 
-## [v0.4.0] - 2020-05-03
+## [0.4.0] - 2020-05-03
 ### Changed
 - prep-cmd is now optional in apps.json
 - Fixed bug causing video artifacts
@@ -85,24 +85,24 @@
 - Fixed bug causing segfault when another session of sunshine was already running
 - Fixed bug causing crash when monitor has resolution 1366x768
 
-## [v0.3.1] - 2020-04-24
+## [0.3.1] - 2020-04-24
 ### Changed
 - Fix a memory leak.
 
-## [v0.3.0] - 2020-04-23
+## [0.3.0] - 2020-04-23
 ### Changed
 - Hardware acceleration on NVidia GPU's for Video encoding on Windows
 
-## [v0.2.0] - 2020-03-21
+## [0.2.0] - 2020-03-21
 ### Changed
 - Multicasting is now supported: You can set the maximum simultaneous connections with the configurable option: channels
 - Configuration variables can be overwritten on the command line: "name=value" --> it can be useful to set min_log_level=debug without modifying the configuration file
 - Switches to make testing the pairing mechanism more convenient has been added, see "sunshine --help" for details
 
-## [v0.1.1] - 2020-01-30
+## [0.1.1] - 2020-01-30
 ### Added
 - (Linux) Added deb package and service for Linux
 
-## [v0.1.0] - 2020-01-27
+## [0.1.0] - 2020-01-27
 ### Added
 - The first official release for Sunshine!


### PR DESCRIPTION
## Description

- changelog parser action fails if "v" is in prefix
- action has already been updated ("v" prefix is added)
  - https://github.com/SunshineStream/actions/blob/29f0d30310e1b7bf7fa251b2b0c1bddcf47fe5a2/verify_changelog/action.yml#L26
  - https://github.com/SunshineStream/actions/blob/29f0d30310e1b7bf7fa251b2b0c1bddcf47fe5a2/verify_changelog/action.yml#L47
  - https://github.com/SunshineStream/actions/blob/29f0d30310e1b7bf7fa251b2b0c1bddcf47fe5a2/verify_changelog/action.yml#L58

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the documentation blocks for new or existing components
