### PR TITLE
video: use a better vbv-bufsize & correct software bitrate calculation

### DIFF
--- a/sunshine/video.cpp
+++ b/sunshine/video.cpp
@@ -930,9 +930,9 @@ std::optional<session_t> make_session(const encoder_t &encoder, const config_t &
   }
 
   if(video_format[encoder_t::CBR]) {
-    auto bitrate        = config.bitrate * 1000;
+    auto bitrate        = config.bitrate * (hardware ? 1000 : 800); // software bitrate overshoots by ~20%
     ctx->rc_max_rate    = bitrate;
-    ctx->rc_buffer_size = bitrate / config.framerate;
+    ctx->rc_buffer_size = bitrate / 10;
     ctx->bit_rate       = bitrate;
     ctx->rc_min_rate    = bitrate;
   }


### PR DESCRIPTION
## Description

Change cherry-picked from @psyke83 repository. It has a real impact on stream quality on my various tests.

* Increase vbv-bufsize to 1/10 of requested bitrate. The previous value
  was too low, which was resulting in poor encoding quality and failure to
  stabilize at the requested bitrate. Setting to 1/10 of bitrate is a
  good compromise, as it avoids quality loss but also prevents bandwidth
  spikes far above the bitrate/vbv-maxrate.
* With vbv-bufsize set to a more appropriate value, testing shows that
  the average bitrate vs client-requested bandwidth overshoots by ~20%.
  Adjust for this scenario in the software encoding case only.

### Screenshot

N/A

### Issues Fixed or Closed

N/A

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated the documentation blocks for new or existing components
