### PR TITLE
Update scripts readme to mention submodules

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -15,6 +15,9 @@ These scripts use docker under the hood, as such, they can only be used to compi
 sudo apt install docker
 ```
 
+You also must have all of this repository's submodules pulled onto your local filesystem. To do this, use `git submodule update --init --recursive`. To ensure it worked, verify that in the repo, `./third-party/moonlight-common-c` has files in it.
+
+
 #### instructions
 
 You'll require one of the following Dockerfiles:


### PR DESCRIPTION
## Description

The build script requires the filesystem has the submodules pulled locally, but the default `git clone` command does not pull these. I've added a note in the scripts readme reminding users to do this.


## Type of Change

This is just a small documentation update.
