### PR TITLE
AVPacket Fix

### DIFF
--- a/sunshine/video.h
+++ b/sunshine/video.h
@@ -16,17 +16,9 @@ extern "C" {
 struct AVPacket;
 namespace video {
 
-struct packet_raw_t : public AVPacket {
+struct packet_raw_t {
   void init_packet() {
-    pts             = AV_NOPTS_VALUE;
-    dts             = AV_NOPTS_VALUE;
-    pos             = -1;
-    duration        = 0;
-    flags           = 0;
-    stream_index    = 0;
-    buf             = nullptr;
-    side_data       = nullptr;
-    side_data_elems = 0;
+    this->av_packet = av_packet_alloc();
   }
 
   template<class P>
@@ -39,7 +31,7 @@ struct packet_raw_t : public AVPacket {
   }
 
   ~packet_raw_t() {
-    av_packet_unref(this);
+    av_packet_unref(this->av_packet);
   }
 
   struct replace_t {
@@ -51,8 +43,8 @@ struct packet_raw_t : public AVPacket {
     replace_t(std::string_view old, std::string_view _new) noexcept : old { std::move(old) }, _new { std::move(_new) } {}
   };
 
+  AVPacket *av_packet;
   std::vector<replace_t> *replacements;
-
   void *channel_data;
 };
 


### PR DESCRIPTION
## Description
This PR changes the codebase to wrap AVPacket instead of extending it.

According to ffmpeg's documentation: 

>sizeof(AVPacket) being a part of the public ABI is deprecated. once av_init_packet() is removed, new packets will only be able to be allocated with [av_packet_alloc()](https://ffmpeg.org/doxygen/trunk/group__lavc__packet.html#gaaf85aa950695631e0217a16062289b66), and new fields may be added to the end of the struct with a minor bump.

I believe this to mean extending AVPacket is fragile and prone to break if things are changed in ffmpeg

In this case, the extended struct did not clear the memory for AVPacket.opaque_ref, so it was not guaranteed to be correctly set to nullptr.

That meant that when encode was called it would try to free a random pointer (since opaque_ref is a AVBuffer) and segfault.
While the issue in question could have been solved by setting that field to nullptr in the constructor, I though changing the codebase to use AVPacket the proper way was the correct move here instead to increase the resiliency of this code.

I have tested this with vaapi encoder with no issues in video (I am having a separate audio issue I plan on looking at) but do not have any other encoders setup to test. (Software encoding is giving me a separate problem, already documented as an issue.)

Note that my C++ is rough, but I believe this should still keep all the correct memory ref/ownership to prevent leaks (and I did not see an increase in memory usage after letting a video steam for some time.)

### Issues Fixed or Closed
- Fixes #124

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the documentation blocks for new or existing components
