### PR TITLE
f35: add libcap-devel to enable KMS code

### DIFF
--- a/scripts/Dockerfile-fedora_33
+++ b/scripts/Dockerfile-fedora_33
@@ -21,6 +21,8 @@ RUN dnf -y update && \
         openssl-devel \
         opus-devel \
         pulseaudio-libs-devel \
+        libcap-devel \
+        libdrm-devel \
         rpm-build \
     && dnf clean all \
     && rm -rf /var/cache/yum

--- a/scripts/Dockerfile-fedora_35
+++ b/scripts/Dockerfile-fedora_35
@@ -25,6 +25,8 @@ RUN dnf -y update && \
         openssl-devel \
         opus-devel \
         pulseaudio-libs-devel \
+        libcap-devel \
+        libdrm-devel \
         rpm-build \
     && dnf clean all \
     && rm -rf /var/cache/yum


### PR DESCRIPTION
## Description

The Fedora 35 docker image doesn't have libcap development files, hence the CMake checks won't enable KMS support. (SUNSHINE_ENABLE_DRM depends on the libcap dev files)

