### PR TITLE
platform/windows: add DwmFlush() call to improve Windows capture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,7 @@ if(WIN32)
 		ws2_32
 		d3d11 dxgi D3DCompiler
 		setupapi
+		dwmapi
 		)
 
 	set_source_files_properties(third-party/ViGEmClient/src/ViGEmClient.cpp PROPERTIES COMPILE_DEFINITIONS "UNICODE=1;ERROR_INVALID_DEVICE_OBJECT_PARAMETER=650")

--- a/docs/source/about/advanced_usage.rst
+++ b/docs/source/about/advanced_usage.rst
@@ -333,6 +333,25 @@ Example
         3840x1600,
       ]
 
+dwmflush
+^^^^^^^^
+
+Description
+   Invoke DwmFlush() to sync screen capture to the Windows presentation interval.
+
+   .. Caution:: Applies to Windows only. Alleviates visual stuttering during mouse movement, but causes the capture
+      rate to be limited to the host monitor's currently active refresh rate.
+
+Default
+   ``disabled``
+
+Examples
+
+   Windows
+      .. code-block:: text
+
+         dwmflush = enabled
+
 Audio
 -----
 

--- a/docs/source/about/advanced_usage.rst
+++ b/docs/source/about/advanced_usage.rst
@@ -339,11 +339,12 @@ dwmflush
 Description
    Invoke DwmFlush() to sync screen capture to the Windows presentation interval.
 
-   .. Caution:: Applies to Windows only. Alleviates visual stuttering during mouse movement, but causes the capture
-      rate to be limited to the host monitor's currently active refresh rate.
+   .. Caution:: Applies to Windows only. Alleviates visual stuttering during mouse movement.
+      If enabled, this feature will automatically deactivate if the client framerate exceeds
+      the host monitor's current refresh rate.
 
 Default
-   ``disabled``
+   ``enabled``
 
 Examples
 

--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -410,8 +410,8 @@
           <option value="enabled">Enabled</option>
         </select>
         <div class="form-text">
-          Improves capture latency during mouse movement.<br />
-          Enabling this may prevent the client's FPS from exceeding the host monitor's active refresh rate.
+          Improves capture latency/smoothness during mouse movement.<br />
+          Disable if you encounter any VSync-related issues.
         </div>
       </div>
       <div class="mb-3" class="config-page" v-if="platform === 'linux'">
@@ -843,7 +843,7 @@
             this.config.key_rightalt_to_key_win || "disabled";
           this.config.gamepad = this.config.gamepad || "x360";
           this.config.upnp = this.config.upnp || "disabled";
-          this.config.dwmflush = this.config.dwmflush || "disabled";
+          this.config.dwmflush = this.config.dwmflush || "enabled";
           this.config.min_log_level = this.config.min_log_level || 2;
           this.config.origin_pin_allowed =
             this.config.origin_pin_allowed || "pc";

--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -696,7 +696,7 @@
         </select>
       </div>
       <div class="mb-3">
-        <label for="amd_coder" class="form-label">AMD AMF Rate Control</label>
+        <label for="amd_coder" class="form-label">AMD AMF Coder</label>
         <select id="amd_coder" class="form-select" v-model="config.amd_coder">
           <option value="auto">auto</option>
           <option value="cabac">cabac</option>
@@ -842,6 +842,7 @@
           this.config.nv_preset = this.config.nv_preset || "default";
           this.config.nv_rc = this.config.nv_rc || "auto";
           this.config.nv_coder = this.config.nv_coder || "auto";
+          this.config.amd_coder = this.config.amd_coder || "auto"
           this.config.amd_quality = this.config.amd_quality || "default";
           this.config.amd_rc = this.config.amd_rc || "auto";
           this.config.vt_coder = this.config.vt_coder || "auto";

--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -37,13 +37,13 @@
           class="form-select"
           v-model="config.min_log_level"
         >
-          <option :value="0">Verbose</option>
-          <option :value="1">Debug</option>
-          <option :value="2">Info</option>
-          <option :value="3">Warning</option>
-          <option :value="4">Error</option>
-          <option :value="5">Fatal</option>
-          <option :value="6">None</option>
+          <option value="0">Verbose</option>
+          <option value="1">Debug</option>
+          <option value="2">Info</option>
+          <option value="3">Warning</option>
+          <option value="4">Error</option>
+          <option value="5">Fatal</option>
+          <option value="6">None</option>
         </select>
         <div class="form-text">
           The minimum log level printed to standard out
@@ -497,7 +497,7 @@
       <div class="mb-3">
         <label for="encoder" class="form-label">Force a Specific Encoder</label>
         <select id="encoder" class="form-select" v-model="config.encoder">
-          <option :value="''">Autodetect</option>
+          <option value>Autodetect</option>
           <option value="nvenc">nVidia NVENC</option>
           <option value="amdvce">AMD AMF/VCE</option>
           <option value="vaapi">VA-API</option>

--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -400,7 +400,18 @@
           You can select the video card you want to stream:<br />
           The appropriate values can be found using the following command:<br />
           tools\dxgi-info.exe<br />
-          <br />
+        </div>
+      </div>
+      <!--DwmFlush-->
+      <div class="mb-3" v-if="platform === 'windows'">
+        <label for="dwmflush" class="form-label">DwmFlush</label>
+        <select id="dwmflush" class="form-select" v-model="config.dwmflush">
+          <option value="disabled">Disabled</option>
+          <option value="enabled">Enabled</option>
+        </select>
+        <div class="form-text">
+          Improves capture latency during mouse movement.<br />
+          Enabling this may prevent the client's FPS from exceeding the host monitor's active refresh rate.
         </div>
       </div>
       <div class="mb-3" class="config-page" v-if="platform === 'linux'">
@@ -832,6 +843,7 @@
             this.config.key_rightalt_to_key_win || "disabled";
           this.config.gamepad = this.config.gamepad || "x360";
           this.config.upnp = this.config.upnp || "disabled";
+          this.config.dwmflush = this.config.dwmflush || "disabled";
           this.config.min_log_level = this.config.min_log_level || 2;
           this.config.origin_pin_allowed =
             this.config.origin_pin_allowed || "pc";

--- a/sunshine/config.cpp
+++ b/sunshine/config.cpp
@@ -226,9 +226,10 @@ video_t video {
     1,
     -1 }, // vt
 
-  {}, // encoder
-  {}, // adapter_name
-  {}, // output_name
+  {},   // encoder
+  {},   // adapter_name
+  {},   // output_name
+  false // dwmflush
 };
 
 audio_t audio {};
@@ -735,6 +736,7 @@ void apply_config(std::unordered_map<std::string, std::string> &&vars) {
   string_f(vars, "encoder", video.encoder);
   string_f(vars, "adapter_name", video.adapter_name);
   string_f(vars, "output_name", video.output_name);
+  bool_f(vars, "dwmflush", video.dwmflush);
 
   path_f(vars, "pkey", nvhttp.pkey);
   path_f(vars, "cert", nvhttp.cert);

--- a/sunshine/config.cpp
+++ b/sunshine/config.cpp
@@ -220,6 +220,12 @@ video_t video {
     std::nullopt,
     -1 }, // amd
 
+  {
+    0,
+    0,
+    1,
+    -1 }, // vt
+
   {}, // encoder
   {}, // adapter_name
   {}, // output_name
@@ -722,11 +728,8 @@ void apply_config(std::unordered_map<std::string, std::string> &&vars) {
   }
 
   int_f(vars, "vt_coder", video.vt.coder, vt::coder_from_view);
-  video.vt.allow_sw = 0;
   int_f(vars, "vt_software", video.vt.allow_sw, vt::allow_software_from_view);
-  video.vt.require_sw = 0;
   int_f(vars, "vt_software", video.vt.require_sw, vt::force_software_from_view);
-  video.vt.realtime = 1;
   int_f(vars, "vt_realtime", video.vt.realtime, vt::rt_from_view);
 
   string_f(vars, "encoder", video.encoder);

--- a/sunshine/config.cpp
+++ b/sunshine/config.cpp
@@ -226,10 +226,10 @@ video_t video {
     1,
     -1 }, // vt
 
-  {},   // encoder
-  {},   // adapter_name
-  {},   // output_name
-  false // dwmflush
+  {},  // encoder
+  {},  // adapter_name
+  {},  // output_name
+  true // dwmflush
 };
 
 audio_t audio {};

--- a/sunshine/config.h
+++ b/sunshine/config.h
@@ -44,6 +44,7 @@ struct video_t {
   std::string encoder;
   std::string adapter_name;
   std::string output_name;
+  bool dwmflush;
 };
 
 struct audio_t {

--- a/sunshine/platform/windows/display.h
+++ b/sunshine/platform/windows/display.h
@@ -8,6 +8,7 @@
 #include <d3d11.h>
 #include <d3d11_4.h>
 #include <d3dcommon.h>
+#include <dwmapi.h>
 #include <dxgi.h>
 #include <dxgi1_2.h>
 

--- a/sunshine/platform/windows/display.h
+++ b/sunshine/platform/windows/display.h
@@ -96,6 +96,7 @@ class duplication_t {
 public:
   dup_t dup;
   bool has_frame {};
+  bool use_dwmflush {};
 
   capture_e next_frame(DXGI_OUTDUPL_FRAME_INFO &frame_info, std::chrono::milliseconds timeout, resource_t::pointer *res_p);
   capture_e reset(dup_t::pointer dup_p = dup_t::pointer());

--- a/sunshine/platform/windows/display_base.cpp
+++ b/sunshine/platform/windows/display_base.cpp
@@ -20,6 +20,10 @@ capture_e duplication_t::next_frame(DXGI_OUTDUPL_FRAME_INFO &frame_info, std::ch
     return capture_status;
   }
 
+  if(config::video.dwmflush) {
+    DwmFlush();
+  }
+
   auto status = dup->AcquireNextFrame(timeout.count(), &frame_info, res_p);
 
   switch(status) {


### PR DESCRIPTION
## Description

Adds  DwmFlush() call before acquiring a new frame to resolve framerate stuttering observed when moving the mouse.  For more context, see (obsolete) PR and issue from upstream that describes the problem in detail:

https://github.com/loki-47-6F-64/sunshine/issues/227
https://github.com/loki-47-6F-64/sunshine/pull/286

Please note that I had to include a very minor but unrelated fix for VideoToolbox variables missing from the video_t struct, as this needed to be fixed in order to accommodate the new `dwmflush` entry correctly.

### Issues Fixed or Closed

- Fixes https://github.com/loki-47-6F-64/sunshine/issues/227

## Type of Change

- [X] Breaking* change (fix or feature that would cause existing functionality to not work as expected)

~~Potential breakage only in specific circumstances when enabled: DwmFlush() constrains the framerate to the host computer's monitor refresh rate, so it may cause issues if the client is streaming at an FPS higher than supported by the host's connected monitor. I would personally prefer for this fix to be enabled by default, as this scenario seems like a rare edge case compared to the stutter that's experienced on all Windows clients. Feedback on whether I should change the default would be appreciated.~~
Breakage should no longer occur, as DwmFlush() is now called only if enabled *and* the host monitor refresh rate meets or exceeds the client requested rate.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated the documentation blocks for new or existing components
