### PR TITLE
Add batch files to add and remove firewall rules

### DIFF
--- a/tools/add-firewall-rule.bat
+++ b/tools/add-firewall-rule.bat
@@ -1,0 +1,7 @@
+@echo off
+
+set RULE_NAME=SunshineStream
+set PROGRAM_BIN="%~dp0sunshine.exe"
+
+rem Add the rule
+netsh advfirewall firewall add rule name=%RULE_NAME% dir=in action=allow program=%PROGRAM_BIN% enable=yes

--- a/tools/delete-firewall-rule.bat
+++ b/tools/delete-firewall-rule.bat
@@ -1,0 +1,6 @@
+@echo off
+
+set RULE_NAME=SunshineStream
+
+rem Delete the rule
+netsh advfirewall firewall delete rule name=%RULE_NAME%


### PR DESCRIPTION
## Description
This change adds batch files to programmatically add and remove sunshine firewall rules. In my use case, if I run `sunshinevc` without opening Sunshine for the first time, Sunshine will silently fail and would not be discoverable within the network, as normally, you would have to deal with this popup first which `sunshinevc` wouldn't show:
![image](https://user-images.githubusercontent.com/56180050/174216521-702d91b0-8e3a-4a98-b90d-a9cbef02cbb8.png)


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->
It works as intended:
![image](https://user-images.githubusercontent.com/56180050/174216667-7200884c-808e-43d9-a4c9-acaa97d996b4.png)
![image](https://user-images.githubusercontent.com/56180050/174216845-4d282834-510d-400a-bf17-8925be22fca5.png)


### Issues Fixed or Closed
<!--- Delete if not relevant. --->
- Fixes #(issue)

## Type of Change
<!--- Please delete options that are not relevant. --->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!--- DO NOT delete any options here. It is okay to have items unchecked! --->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring/documentation-blocks for new or existing methods/components
